### PR TITLE
Changed for correct SQL generation with alter of index/keys. Before t…

### DIFF
--- a/schemasync/schemasync.py
+++ b/schemasync/schemasync.py
@@ -201,7 +201,8 @@ def app(sourcedb='', targetdb='', version_filename=False,
 
     # data transformation filters
     filters = (lambda d: utils.REGEX_MULTI_SPACE.sub(' ', d),
-                lambda d: utils.REGEX_DISTANT_SEMICOLIN.sub(';', d))
+                lambda d: utils.REGEX_DISTANT_SEMICOLIN.sub(';', d),
+                lambda d: utils.REGEX_SEMICOLON_EXPLODE_TO_NEWLINE.sub(";\n", d))
 
     # Information about this run, used in the patch/revert templates
     ctx = dict(app_version=APPLICATION_VERSION,

--- a/schemasync/syncdb.py
+++ b/schemasync/syncdb.py
@@ -47,9 +47,19 @@ def sync_schema(fromdb, todb, options):
             rlist.append(r)
 
         if plist and rlist:
-            p = "%s %s;" % (to_table.alter(), ', '.join(plist))
-            r = "%s %s;" % (to_table.alter(), ', '.join(rlist))
-            yield p, r
+	    # every expression in alter line must be separate SQL request, not united SQL.
+	    p = "\n";
+	    for i in plist:
+	        p = "%s %s %s;" % (p, to_table.alter(), i)
+	        p = p + "\n"
+	    
+	    r = "\n";
+	    for i in rlist:
+	        r = "%s %s %s;" % (r, to_table.alter(), i)
+	        r = r + "\n"
+
+
+        yield p, r
 
 
 def sync_table(from_table, to_table, options):

--- a/schemasync/utils.py
+++ b/schemasync/utils.py
@@ -13,6 +13,7 @@ REGEX_DISTANT_SEMICOLIN = re.compile(r'(\s+;)$')
 REGEX_FILE_COUNTER = re.compile(r"\_(?P<i>[0-9]+)\.(?:[^\.]+)$")
 REGEX_TABLE_COMMENT = re.compile(r"COMMENT(?:(?:\s*=\s*)|\s*)'(.*?)'", re.I)
 REGEX_TABLE_AUTO_INC = re.compile(r"AUTO_INCREMENT(?:(?:\s*=\s*)|\s*)(\d+)", re.I)
+REGEX_SEMICOLON_EXPLODE_TO_NEWLINE = re.compile(r';\s+')
 
 
 def versioned(filename):


### PR DESCRIPTION
…his changes every alteration of foreign key or index (for example: add or deleting column for index) was generate single line with deletion and recreation of index/key. It was break SQL flow of alter index for some cases. Now - fixed.

Every semicolon now break the line for more comfortable reading.
